### PR TITLE
feat: add contacts service with CRUD and search

### DIFF
--- a/docs/service-contacts.md
+++ b/docs/service-contacts.md
@@ -4,12 +4,27 @@ Ubicación: `services/contacts`
 
 Responsabilidades:
 - CRUD de contactos
-- Búsqueda y filtrado, etiquetas y atributos
+- Búsqueda y filtrado por etiquetas y atributos
 
-Variables de entorno:
+## Endpoints
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| `POST` | `/api/contacts` | Crea un contacto. |
+| `GET` | `/api/contacts` | Lista todos los contactos. |
+| `GET` | `/api/contacts/{id}` | Obtiene un contacto por `id`. |
+| `PUT` | `/api/contacts/{id}` | Actualiza un contacto. |
+| `DELETE` | `/api/contacts/{id}` | Elimina un contacto. |
+| `GET` | `/api/contacts/search` | Filtra por `tags` y `attr_key/attr_value`. |
+
+Parámetros de búsqueda:
+- `tags`: repetir el parámetro para buscar por múltiples etiquetas.
+- `attr_key` y `attr_value`: par clave/valor para comparar con `attributes`.
+
+## Variables de entorno
 - `DATABASE_URL`
 
-Ejecutar en dev:
+## Ejecutar en dev
 ```powershell
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,4 @@ addopts = -q
 # explicitly ignore these test files since we have service-specific copies
 # (these are leftovers from earlier iterations)
 # pytest doesn't have an `ignore_files` setting, so exclude via testpaths instead
-testpaths = services/flow-engine/tests services/messaging-gateway/tests
+testpaths = services/flow-engine/tests services/messaging-gateway/tests services/contacts/tests

--- a/services/contacts/app/main.py
+++ b/services/contacts/app/main.py
@@ -1,1 +1,140 @@
-# main.py para contacts
+from fastapi import FastAPI, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from packages.common.db import SessionLocal, engine
+from packages.common.models import Contact
+
+app = FastAPI(title="NexIA Contacts")
+
+
+# Create tables on startup (no-op if already exist)
+@app.on_event("startup")
+def on_startup() -> None:
+    Contact.__table__.create(bind=engine, checkfirst=True)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Pydantic schemas ---------------------------------------------------------
+class ContactBase(BaseModel):
+    org_id: str
+    wa_id: Optional[str] = None
+    phone: Optional[str] = None
+    name: Optional[str] = None
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    consent: Optional[str] = None
+    locale: Optional[str] = None
+    timezone: Optional[str] = None
+
+
+class ContactCreate(ContactBase):
+    id: Optional[str] = None
+
+
+class ContactUpdate(BaseModel):
+    wa_id: Optional[str] = None
+    phone: Optional[str] = None
+    name: Optional[str] = None
+    attributes: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+    consent: Optional[str] = None
+    locale: Optional[str] = None
+    timezone: Optional[str] = None
+
+
+class ContactOut(ContactBase):
+    id: str
+
+    class Config:
+        orm_mode = True
+
+
+# Routes -------------------------------------------------------------------
+@app.post("/api/contacts", response_model=ContactOut, status_code=201)
+def create_contact(payload: ContactCreate, db: Session = Depends(get_db)):
+    cid = payload.id or str(uuid4())
+    contact = Contact(
+        id=cid,
+        org_id=payload.org_id,
+        wa_id=payload.wa_id,
+        phone=payload.phone,
+        name=payload.name,
+        attributes=payload.attributes,
+        tags=payload.tags,
+        consent=payload.consent,
+        locale=payload.locale,
+        timezone=payload.timezone,
+    )
+    db.add(contact)
+    db.commit()
+    db.refresh(contact)
+    return contact
+
+
+@app.get("/api/contacts", response_model=List[ContactOut])
+def list_contacts(db: Session = Depends(get_db)):
+    return db.query(Contact).all()
+
+
+@app.get("/api/contacts/{contact_id}", response_model=ContactOut)
+def get_contact(contact_id: str, db: Session = Depends(get_db)):
+    contact = db.get(Contact, contact_id)
+    if not contact:
+        raise HTTPException(status_code=404, detail="contact not found")
+    return contact
+
+
+@app.put("/api/contacts/{contact_id}", response_model=ContactOut)
+def update_contact(contact_id: str, payload: ContactUpdate, db: Session = Depends(get_db)):
+    contact = db.get(Contact, contact_id)
+    if not contact:
+        raise HTTPException(status_code=404, detail="contact not found")
+    for field, value in payload.dict(exclude_unset=True).items():
+        setattr(contact, field, value)
+    db.commit()
+    db.refresh(contact)
+    return contact
+
+
+@app.delete("/api/contacts/{contact_id}")
+def delete_contact(contact_id: str, db: Session = Depends(get_db)):
+    contact = db.get(Contact, contact_id)
+    if not contact:
+        raise HTTPException(status_code=404, detail="contact not found")
+    db.delete(contact)
+    db.commit()
+    return {"ok": True}
+
+
+@app.get("/api/contacts/search", response_model=List[ContactOut])
+def search_contacts(
+    tags: Optional[List[str]] = Query(None),
+    attr_key: Optional[str] = None,
+    attr_value: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    contacts = db.query(Contact).all()
+    if tags:
+        contacts = [c for c in contacts if set(tags).issubset(set(c.tags or []))]
+    if attr_key and attr_value:
+        contacts = [
+            c for c in contacts
+            if c.attributes and str(c.attributes.get(attr_key)) == attr_value
+        ]
+    return contacts
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}

--- a/services/contacts/tests/test_contacts_api.py
+++ b/services/contacts/tests/test_contacts_api.py
@@ -1,0 +1,92 @@
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, String
+from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy.orm import declarative_base
+
+TestBase = declarative_base()
+
+
+class TestContact(TestBase):
+    __tablename__ = "contacts"
+    id = Column(String, primary_key=True)
+    org_id = Column(String)
+    wa_id = Column(String)
+    phone = Column(String)
+    name = Column(String)
+    attributes = Column(JSON, default=dict)
+    tags = Column(JSON, default=list)
+    consent = Column(String)
+    locale = Column(String)
+    timezone = Column(String)
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["DATABASE_URL"] = f"sqlite:///{tmpdir}/test.db"
+        root = Path(__file__).resolve().parents[3]
+        sys.path.append(str(root))
+        import services.contacts.app.main as main  # noqa: E402
+        from packages.common.db import SessionLocal, engine  # noqa: E402
+
+        main.Contact = TestContact
+        TestBase.metadata.create_all(bind=engine)
+
+        def override_get_db():
+            db = SessionLocal()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        main.app.dependency_overrides[main.get_db] = override_get_db
+        with TestClient(main.app) as c:
+            yield c
+        main.app.dependency_overrides.clear()
+
+
+def test_crud_and_search(client: TestClient):
+    payload = {
+        "org_id": "o1",
+        "name": "Ana",
+        "phone": "123",
+        "tags": ["vip"],
+        "attributes": {"city": "CDMX"},
+    }
+    r = client.post("/api/contacts", json=payload)
+    assert r.status_code == 201
+    data = r.json()
+    cid = data["id"]
+    assert data["name"] == "Ana"
+
+    r = client.get(f"/api/contacts/{cid}")
+    assert r.status_code == 200
+    assert r.json()["name"] == "Ana"
+
+    r = client.put(f"/api/contacts/{cid}", json={"name": "Ana Maria"})
+    assert r.json()["name"] == "Ana Maria"
+
+    r = client.get("/api/contacts")
+    assert len(r.json()) == 1
+
+    r = client.get("/api/contacts/search", params={"tags": "vip"})
+    assert len(r.json()) == 1
+
+    r = client.get(
+        "/api/contacts/search", params={"attr_key": "city", "attr_value": "CDMX"}
+    )
+    assert len(r.json()) == 1
+
+    r = client.delete(f"/api/contacts/{cid}")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    r = client.get(f"/api/contacts/{cid}")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
- implement FastAPI contacts service with create/list/get/update/delete and search by tags or attributes
- document contacts service endpoints
- add basic unit tests and enable test discovery

## Testing
- `pre-commit run --files docs/service-contacts.md pytest.ini services/contacts/app/main.py services/contacts/tests/test_contacts_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0ccc451dc83338594d4b9bb27bc35