### PR TITLE
docs: DevStack - pin psycopg and note FastAPI lifespan/Pydantic compatibility

### DIFF
--- a/DevStack.md
+++ b/DevStack.md
@@ -574,7 +574,7 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 redis==5.0.7
 sqlalchemy==2.0.32
-psycopg[binary]==3.2.1
+psycopg[binary]==3.2.10
 sse-starlette==2.1.0
 python-dotenv==1.0.1
 ```
@@ -646,6 +646,8 @@ async def inbox_stream():
                     last_id = msg_id
     return EventSourceResponse(event_gen())
 ```
+
+Note: The repository implementation was later updated to use a FastAPI lifespan handler for startup logic and a Pydantic v1/v2-friendly pattern for payloads (using `model_dump()` when available). See `services/api-gateway/app/main.py` for the current code.
 
 ---
 
@@ -876,7 +878,7 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
 sqlalchemy==2.0.32
-psycopg[binary]==3.2.1
+psycopg[binary]==3.2.10
 ```
 
 ### `services/contacts/app/main.py`

--- a/services/api-gateway/README.md
+++ b/services/api-gateway/README.md
@@ -1,0 +1,22 @@
+API Gateway (NexIA)
+
+Notes
+- SSE inbox streaming uses the optional dependency `sse-starlette`. If you want inbox streaming available in your environment, install the dependencies in `requirements.txt` or add `sse-starlette` to your environment.
+- To avoid import-time failures when `sse-starlette` is not installed, the application imports `EventSourceResponse` lazily and returns HTTP 501 for the `/api/inbox/stream` endpoint when the package is missing.
+
+Pydantic compatibility
+- The project aims to be compatible with both Pydantic v1 and v2. API handlers use `getattr(model, 'model_dump', model.dict)()` or a small `if hasattr(..., 'model_dump')` fallback to support both versions.
+
+How to run locally (dev)
+
+1. Create a virtualenv and install deps:
+
+```powershell
+python -m venv .venv; .\.venv\Scripts\Activate.ps1; pip install -r services/api-gateway/requirements.txt
+```
+
+2. Run the service (example):
+
+```powershell
+uvicorn services.api-gateway.app.main:app --reload --port 8000
+```


### PR DESCRIPTION
Pin psycopg[binary] to 3.2.10 in docs and add a short note about the API gateway using a FastAPI lifespan handler and Pydantic v1/v2-safe patterns.