### PR TITLE
feat: add status and metrics endpoints

### DIFF
--- a/docs/service-messaging-gateway.md
+++ b/docs/service-messaging-gateway.md
@@ -3,11 +3,15 @@
 Ubicación: `services/messaging-gateway`
 
 Responsabilidades:
-- Exponer endpoints internos de estado
+- Exponer endpoints internos de estado y métricas (`GET /internal/status`, `GET /internal/metrics`)
 - Worker `send_worker.py` que consume `nf:outbox` y envía a la API de WhatsApp (o simula si FAKE)
 
 Variables de entorno:
 - `REDIS_URL`, `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_FAKE_MODE`
+
+Endpoints internos:
+- `GET /internal/status` — muestra modo del `send_worker` y datos básicos de Redis.
+- `GET /internal/metrics` — entrega contadores de los streams `nf:outbox` y `nf:sent`.
 
 Ejecutar worker en dev:
 ```powershell

--- a/services/messaging-gateway/app/main.py
+++ b/services/messaging-gateway/app/main.py
@@ -1,1 +1,48 @@
-# main.py para messaging-gateway
+import os
+from fastapi import FastAPI
+from redis import Redis
+
+
+app = FastAPI(title="NexIA Messaging Gateway")
+
+# Reutiliza la misma configuración de Redis que el worker
+redis = Redis.from_url(
+    os.getenv("REDIS_URL", "redis://redis:6379/0"), decode_responses=True
+)
+
+# Configuración usada por el worker para exponer su estado
+FAKE = os.getenv("WHATSAPP_FAKE_MODE", "true").lower() == "true"
+TOKEN = os.getenv("WHATSAPP_TOKEN", "")
+PHONE_ID = os.getenv("WHATSAPP_PHONE_NUMBER_ID", "")
+
+
+@app.get("/internal/status")
+async def status():
+    """Devuelve información básica del servicio y del worker."""
+    worker_info = {
+        "fake": FAKE,
+        "has_token": bool(TOKEN),
+        "phone_id": PHONE_ID,
+    }
+    return {"workers": {"send_worker": worker_info}}
+
+
+@app.get("/internal/metrics")
+async def metrics():
+    """Entrega métricas simples basadas en Redis."""
+    data = {}
+    try:
+        data["nf_outbox"] = redis.xlen("nf:outbox")
+    except Exception:
+        data["nf_outbox"] = None
+    try:
+        data["nf_sent"] = redis.xlen("nf:sent")
+    except Exception:
+        data["nf_sent"] = None
+    return {"streams": data}
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}
+


### PR DESCRIPTION
## Summary
- build FastAPI app for Messaging Gateway service
- expose `/internal/status` and `/internal/metrics`
- document internal endpoints and worker info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0e7626e708333ab1feeda89a17ff7