### PR TITLE
feat: real WhatsApp send with retries

### DIFF
--- a/services/messaging-gateway/tests/test_send_worker.py
+++ b/services/messaging-gateway/tests/test_send_worker.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 import asyncio
+import httpx
 
 # Load module by path to avoid package name issues
 root = Path(__file__).resolve().parents[3]
@@ -30,3 +31,49 @@ def test_process_message_forwards_orig_text():
     assert stream == "nf:sent"
     assert mapping.get("orig_text") == "PIPE_ENTER_TEST"
     assert mapping.get("client_id") == "cid1"
+
+
+def test_process_message_fake_mode(monkeypatch):
+    fake = FakeRedis()
+    send_worker.redis = fake
+    send_worker.FAKE = True
+
+    called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        called["count"] += 1
+        return httpx.Response(200, json={})
+
+    monkeypatch.setattr(send_worker.httpx, "post", fake_post)
+
+    fields = {"to": "123", "text": "hi", "client_id": "cid1"}
+    asyncio.run(send_worker.process_message("1-0", fields))
+
+    assert called["count"] == 0, "httpx.post should not be called in fake mode"
+    stream, mapping = fake.xadd_calls[0]
+    assert mapping.get("fake") == "True"
+
+
+def test_process_message_real_mode(monkeypatch):
+    fake = FakeRedis()
+    send_worker.redis = fake
+    send_worker.FAKE = False
+    send_worker.TOKEN = "token"
+    send_worker.PHONE_ID = "111"
+
+    called = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called["url"] = url
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"messages": [{"id": "msg1"}]}, request=request)
+
+    monkeypatch.setattr(send_worker.httpx, "post", fake_post)
+
+    fields = {"to": "123", "text": "hi", "client_id": "cid1"}
+    asyncio.run(send_worker.process_message("1-1", fields))
+
+    assert called["url"].endswith("/111/messages"), "expected WhatsApp API URL"
+    stream, mapping = fake.xadd_calls[0]
+    assert mapping.get("fake") == "False"
+    assert mapping.get("wa_msg_id") == "msg1"

--- a/services/messaging-gateway/worker/send_worker.py
+++ b/services/messaging-gateway/worker/send_worker.py
@@ -1,4 +1,6 @@
-import os, asyncio, json, time, logging
+import os, asyncio, time, logging
+
+import httpx
 from pythonjsonlogger import json as jsonlogger
 from redis import Redis
 
@@ -15,67 +17,88 @@ logger.addHandler(handler)
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
 
 async def process_message(msg_id: str, fields: dict):
-	to = fields.get("to")
-	text = fields.get("text") or (fields.get("body") or "")
-	client_id = fields.get("client_id")
-	if FAKE:
-		result = {"fake": True, "to": to, "text": text, "client_id": client_id, "ts": time.time()}
-		# preserve original text if present for tracing
-		if fields.get('orig_text'):
-			result['orig_text'] = fields.get('orig_text')
-		# preserve trace_id if provided
-		if fields.get('trace_id'):
-			result['trace_id'] = fields.get('trace_id')
-	else:
-		# real send would be implemented here (httpx.post to WhatsApp API)
-		result = {"fake": False, "to": to, "text": text, "client_id": client_id, "ts": time.time()}
-		if fields.get('orig_text'):
-			result['orig_text'] = fields.get('orig_text')
-		if fields.get('trace_id'):
-			result['trace_id'] = fields.get('trace_id')
-	try:
-		# ensure all values are strings for redis stream
-		redis.xadd("nf:sent", {k: str(v) for k, v in result.items()})
-	except Exception:
-		logger.exception("send_worker xadd error")
-	# log with trace_id when available for correlation
-	if result.get('trace_id'):
-		logger.info("processed %s", msg_id, extra={"trace_id": result.get('trace_id'), "to": result.get('to'), "client_id": result.get('client_id')})
-	else:
-		logger.info("processed %s %s", msg_id, result)
+    to = fields.get("to")
+    text = fields.get("text") or (fields.get("body") or "")
+    client_id = fields.get("client_id")
+    if FAKE:
+        result = {"fake": True, "to": to, "text": text, "client_id": client_id, "ts": time.time()}
+        if fields.get('orig_text'):
+            result['orig_text'] = fields.get('orig_text')
+        if fields.get('trace_id'):
+            result['trace_id'] = fields.get('trace_id')
+    else:
+        url = f"https://graph.facebook.com/v20.0/{PHONE_ID}/messages"
+        headers = {"Authorization": f"Bearer {TOKEN}"}
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": to,
+            "type": "text",
+            "text": {"body": text},
+        }
+        wa_msg_id = None
+        for attempt in range(3):
+            try:
+                resp = await asyncio.to_thread(
+                    httpx.post, url, headers=headers, json=payload, timeout=10
+                )
+                logger.info("whatsapp %s %s", resp.status_code, resp.text)
+                resp.raise_for_status()
+                wa_msg_id = resp.json().get("messages", [{}])[0].get("id")
+                break
+            except Exception:
+                logger.exception("whatsapp send attempt %s failed", attempt + 1)
+                if attempt < 2:
+                    await asyncio.sleep(2 ** attempt)
+        result = {"fake": False, "to": to, "text": text, "client_id": client_id, "ts": time.time()}
+        if wa_msg_id:
+            result["wa_msg_id"] = wa_msg_id
+        if fields.get('orig_text'):
+            result['orig_text'] = fields.get('orig_text')
+        if fields.get('trace_id'):
+            result['trace_id'] = fields.get('trace_id')
+    try:
+        # ensure all values are strings for redis stream
+        redis.xadd("nf:sent", {k: str(v) for k, v in result.items()})
+    except Exception:
+        logger.exception("send_worker xadd error")
+    # log with trace_id when available for correlation
+    if result.get('trace_id'):
+        logger.info("processed %s", msg_id, extra={"trace_id": result.get('trace_id'), "to": result.get('to'), "client_id": result.get('client_id')})
+    else:
+        logger.info("processed %s %s", msg_id, result)
 
 async def loop():
-	# start from the beginning in dev so backlog is processed
-	last_id = "0-0"
-	logger.info("send_worker starting (FAKE=%s)", FAKE)
-	while True:
-		try:
-			# Use Redis XREAD via execute_command for consistent blocking reads
-			raw = await asyncio.to_thread(redis.execute_command, 'XREAD', 'BLOCK', 5000, 'COUNT', 1, 'STREAMS', 'nf:outbox', last_id)
-			if not raw:
-				await asyncio.sleep(0.1)
-				continue
-			for stream_item in raw:
-				msgs = stream_item[1]
-				for msg in msgs:
-					msg_id = msg[0].decode() if isinstance(msg[0], bytes) else msg[0]
-					kvs = msg[1]
-					# redis client may return fields as a dict or a flat list of pairs
-					fields = {}
-					if isinstance(kvs, dict):
-						# values already decoded when decode_responses=True
-						for k, v in kvs.items():
-							fields[str(k)] = str(v)
-					else:
-						for i in range(0, len(kvs), 2):
-							k = kvs[i].decode() if isinstance(kvs[i], bytes) else kvs[i]
-							v = kvs[i+1].decode() if isinstance(kvs[i+1], bytes) else kvs[i+1]
-							fields[k] = v
-					last_id = msg_id
-					await process_message(msg_id, fields)
-		except Exception:
-			logger.exception("send_worker loop error")
-			await asyncio.sleep(1)
+    # start from the beginning in dev so backlog is processed
+    last_id = "0-0"
+    logger.info("send_worker starting (FAKE=%s)", FAKE)
+    while True:
+        try:
+            # Use Redis XREAD via execute_command for consistent blocking reads
+            raw = await asyncio.to_thread(redis.execute_command, 'XREAD', 'BLOCK', 5000, 'COUNT', 1, 'STREAMS', 'nf:outbox', last_id)
+            if not raw:
+                await asyncio.sleep(0.1)
+                continue
+            for stream_item in raw:
+                msgs = stream_item[1]
+                for msg in msgs:
+                    msg_id = msg[0].decode() if isinstance(msg[0], bytes) else msg[0]
+                    kvs = msg[1]
+                    # redis client may return fields as a dict or a flat list of pairs
+                    fields = {}
+                    if isinstance(kvs, dict):
+                        # values already decoded when decode_responses=True
+                        for k, v in kvs.items():
+                            fields[str(k)] = str(v)
+                    else:
+                        for i in range(0, len(kvs), 2):
+                            k = kvs[i].decode() if isinstance(kvs[i], bytes) else kvs[i]
+                            v = kvs[i+1].decode() if isinstance(kvs[i+1], bytes) else kvs[i+1]
+                            fields[k] = v
+                    last_id = msg_id
+                    await process_message(msg_id, fields)
+        except Exception:
+            logger.exception("send_worker loop error")
+            await asyncio.sleep(1)
 
 if __name__ == "__main__":
-	asyncio.run(loop())
+    asyncio.run(loop())


### PR DESCRIPTION
## Summary
- send real messages to WhatsApp Graph API when fake mode disabled
- add retry logic, logging, and store WhatsApp message ID
- test worker behavior for fake and real modes

## Testing
- `pytest services/messaging-gateway/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0e87b91508333827ae3c9f04c2783